### PR TITLE
Feat/33 tabs action ux - Add three dots kebab menu visible only on hover of active tab 

### DIFF
--- a/frontend/src/components/ToC.vue
+++ b/frontend/src/components/ToC.vue
@@ -31,7 +31,7 @@
           v-for="(tab, index) in tabs"
           :key="tab.id"
           :class="[
-            'relative transition-all duration-200',
+            'relative transition-all duration-200 group',
             dragState.isDragging && dragState.draggedId === tab.id && 'opacity-0',
           ]"
           @dragover.prevent="onDragOver($event, index)"
@@ -60,35 +60,42 @@
             </TextInput>
           </div>
           <component v-else :is="tab.id === activeTabId ? ContextMenu : 'div'" :items="tabActions">
-            <Button
-              variant="ghost"
-              class="w-full !text-ink-gray-5 !justify-start cursor-grab active:cursor-grabbing"
-              :class="tab.id === activeTabId && 'font-medium !text-ink-gray-8'"
-              :label="tab.label"
-              :icon-left="h(LucideFileText, { class: 'size-4 shrink-0' })"
-              @click="tab.id !== activeTabId && editor.commands.changeTab(tab.id)"
-              :draggable="editor.isEditable"
-              @dragstart="onDragStart($event, tab, index)"
-              @dragend.prevent="onDragEnd"
-            >
-              <template #suffix v-if="tab.id === activeTabId">
-                <div class="flex gap-1 ml-auto">
-                  <Button
-                    @click.stop="showHeadings = !showHeadings"
-                    variant="ghost"
-                    :icon="h(showHeadings ? LucideMinus : LucidePlus, { class: 'size-4' })"
-                  />
-
-                  <Dropdown :options="tabActions">
-                    <Button
-                      variant="ghost"
-                      :icon="h(LucideMoreVertical, { class: 'size-4' })"
-                      @click.stop
-                    />
-                  </Dropdown>
-                </div>
-              </template>
-            </Button>
+            <div class="relative flex items-center">
+              <Button
+                v-if="tab.id === activeTabId"
+                @click.stop="showHeadings = !showHeadings"
+                variant="ghost"
+                class="!absolute !p-0.5 !size-6 z-10 left-0.5"
+                :icon="h(showHeadings ? LucideMinus : LucidePlus, { class: 'size-3.5' })"
+                :tooltip="showHeadings ? 'Collapse' : 'Expand'"
+              />
+              <Button
+                variant="ghost"
+                class="w-full !text-ink-gray-5 !justify-start cursor-grab active:cursor-grabbing"
+                :class="[
+                  tab.id === activeTabId && 'font-medium !text-ink-gray-8',
+                  tab.id === activeTabId && '!pl-8',
+                ]"
+                :label="tab.label"
+                :icon-left="h(LucideFileText, { class: 'size-4 shrink-0' })"
+                @click="tab.id !== activeTabId && editor.commands.changeTab(tab.id)"
+                :draggable="editor.isEditable"
+                @dragstart="onDragStart($event, tab, index)"
+                @dragend.prevent="onDragEnd"
+              >
+                <template #suffix v-if="tab.id === activeTabId">
+                  <div class="ml-auto opacity-0 group-hover:opacity-100 transition-opacity">
+                    <Dropdown :options="tabActions">
+                      <Button
+                        variant="ghost"
+                        :icon="h(LucideMoreVertical, { class: 'size-4' })"
+                        @click.stop
+                      />
+                    </Dropdown>
+                  </div>
+                </template>
+              </Button>
+            </div>
           </component>
           <template v-if="tab.id === activeTabId && currentTabAnchors.length">
             <div v-if="showHeadings" class="table-of-contents flex flex-col gap-0.5 ms-6 my-1">

--- a/frontend/src/components/ToC.vue
+++ b/frontend/src/components/ToC.vue
@@ -18,9 +18,7 @@
     </div>
     <div v-if="show" class="grow flex flex-col gap-0.5">
       <div class="flex justify-between items-center ps-2 pr-1 pb-1">
-        <span class="text-base font-medium text-ink-gray-8 select-none"
-          >Table of Contents</span
-        >
+        <span class="text-base font-medium text-ink-gray-8 select-none">Table of Contents</span>
         <Button
           :icon="LucideLeftClose"
           variant="ghost"
@@ -28,19 +26,13 @@
           :tooltip="show ? 'Hide' : 'Table of Contents'"
         />
       </div>
-      <div
-        v-if="tabs.length > 0"
-        class="flex flex-col gap-0.5 mb-2"
-        @drop.prevent="onDrop"
-      >
+      <div v-if="tabs.length > 0" class="flex flex-col gap-0.5 mb-2" @drop.prevent="onDrop">
         <div
           v-for="(tab, index) in tabs"
           :key="tab.id"
           :class="[
             'relative transition-all duration-200',
-            dragState.isDragging &&
-              dragState.draggedId === tab.id &&
-              'opacity-0',
+            dragState.isDragging && dragState.draggedId === tab.id && 'opacity-0',
           ]"
           @dragover.prevent="onDragOver($event, index)"
         >
@@ -53,10 +45,7 @@
             "
             class="h-8 my-0.5 border border-dashed rounded-sm mx-2"
           />
-          <div
-            v-if="editingTabId === tab.id && delayedEdit"
-            class="flex items-center"
-          >
+          <div v-if="editingTabId === tab.id && delayedEdit" class="flex items-center">
             <TextInput
               v-model="editingTabLabel"
               v-on-outside-click="() => finishRenaming(false)"
@@ -70,42 +59,39 @@
               </template>
             </TextInput>
           </div>
-          <component
-            v-else
-            :is="tab.id === activeTabId ? ContextMenu : 'div'"
-            :items="tabActions"
-          >
+          <component v-else :is="tab.id === activeTabId ? ContextMenu : 'div'" :items="tabActions">
             <Button
               variant="ghost"
               class="w-full !text-ink-gray-5 !justify-start cursor-grab active:cursor-grabbing"
               :class="tab.id === activeTabId && 'font-medium !text-ink-gray-8'"
               :label="tab.label"
               :icon-left="h(LucideFileText, { class: 'size-4 shrink-0' })"
-              @click="
-                tab.id !== activeTabId && editor.commands.changeTab(tab.id)
-              "
+              @click="tab.id !== activeTabId && editor.commands.changeTab(tab.id)"
               :draggable="editor.isEditable"
               @dragstart="onDragStart($event, tab, index)"
               @dragend.prevent="onDragEnd"
             >
-              <template #suffix v-if="tab.id === activeTabId"
-                ><Button
-                  @click="showHeadings = !showHeadings"
-                  class="ml-auto"
-                  variant="ghost"
-                  :icon="
-                    h(showHeadings ? LucideMinus : LucidePlus, {
-                      class: 'size-4',
-                    })
-                  "
-              /></template>
+              <template #suffix v-if="tab.id === activeTabId">
+                <div class="flex gap-1 ml-auto">
+                  <Button
+                    @click.stop="showHeadings = !showHeadings"
+                    variant="ghost"
+                    :icon="h(showHeadings ? LucideMinus : LucidePlus, { class: 'size-4' })"
+                  />
+
+                  <Dropdown :options="tabActions">
+                    <Button
+                      variant="ghost"
+                      :icon="h(LucideMoreVertical, { class: 'size-4' })"
+                      @click.stop
+                    />
+                  </Dropdown>
+                </div>
+              </template>
             </Button>
           </component>
           <template v-if="tab.id === activeTabId && currentTabAnchors.length">
-            <div
-              v-if="showHeadings"
-              class="table-of-contents flex flex-col gap-0.5 ms-6 my-1"
-            >
+            <div v-if="showHeadings" class="table-of-contents flex flex-col gap-0.5 ms-6 my-1">
               <div v-for="anchor in currentTabAnchors" class="flex pr-2.5">
                 <a
                   :href="'#' + anchor.id"
@@ -115,8 +101,7 @@
                   @click.prevent="onAnchorClick(anchor.id)"
                   :key="anchor.id"
                   :class="
-                    anchor.isActive &&
-                    'text-ink-gray-8 bg-surface-gray-3 hover:bg-surface-gray-4'
+                    anchor.isActive && 'text-ink-gray-8 bg-surface-gray-3 hover:bg-surface-gray-4'
                   "
                   :style="{ '--level': anchor.level - maxLevel }"
                 >
@@ -178,8 +163,9 @@ import LucidePencil from '~icons/lucide/pencil'
 import LucideLink from '~icons/lucide/link'
 import LucideTrash from '~icons/lucide/trash'
 import LucideLeftClose from '~icons/lucide/panel-left-close'
+import LucideMoreVertical from '~icons/lucide/more-vertical'
 import { ref, watch, computed, h, onMounted, onBeforeUnmount } from 'vue'
-import { TextInput, ContextMenu } from 'frappe-ui'
+import { TextInput, ContextMenu, Dropdown } from 'frappe-ui'
 import { copyToClipboard } from 'frappe-ui/drive/js/utils'
 
 const props = defineProps({
@@ -240,9 +226,7 @@ const currentTabAnchors = computed(() => {
 
   // Filter anchors that are within the active tab's position range
   return props.anchors.filter((anchor) => {
-    const element = props.editor.view.dom.querySelector(
-      `[data-toc-id="${anchor.id}"]`,
-    )
+    const element = props.editor.view.dom.querySelector(`[data-toc-id="${anchor.id}"]`)
     if (!element) return false
 
     const pos = props.editor.view.posAtDOM(element, 0)
@@ -251,9 +235,7 @@ const currentTabAnchors = computed(() => {
 })
 
 const maxLevel = computed(() =>
-  currentTabAnchors.value.length
-    ? Math.min(...currentTabAnchors.value.map((k) => k.level)) - 1
-    : 0,
+  currentTabAnchors.value.length ? Math.min(...currentTabAnchors.value.map((k) => k.level)) - 1 : 0
 )
 
 const onAnchorClick = (id) => {
@@ -292,10 +274,7 @@ const startRenaming = (tabId) => {
 
 const finishRenaming = (esc = false) => {
   if (!esc && editingTabId.value && editingTabLabel.value.trim()) {
-    props.editor.commands.renameTab(
-      editingTabId.value,
-      editingTabLabel.value.trim(),
-    )
+    props.editor.commands.renameTab(editingTabId.value, editingTabLabel.value.trim())
   }
   editingTabId.value = null
   editingTabLabel.value = ''
@@ -407,10 +386,7 @@ const tabActions = [
   {
     label: 'Copy Link',
     icon: LucideLink,
-    onClick: () =>
-      copyToClipboard(
-        window.location.href.split('#')[0] + '#' + activeTabId.value,
-      ),
+    onClick: () => copyToClipboard(window.location.href.split('#')[0] + '#' + activeTabId.value),
   },
   {
     group: true,

--- a/frontend/src/components/ToC.vue
+++ b/frontend/src/components/ToC.vue
@@ -62,27 +62,30 @@
           <component v-else :is="tab.id === activeTabId ? ContextMenu : 'div'" :items="tabActions">
             <div class="relative flex items-center">
               <Button
-                v-if="tab.id === activeTabId"
-                @click.stop="showHeadings = !showHeadings"
-                variant="ghost"
-                class="!absolute !p-0.5 !size-6 z-10 left-0.5"
-                :icon="h(showHeadings ? LucideMinus : LucidePlus, { class: 'size-3.5' })"
-                :tooltip="showHeadings ? 'Collapse' : 'Expand'"
-              />
-              <Button
                 variant="ghost"
                 class="w-full !text-ink-gray-5 !justify-start cursor-grab active:cursor-grabbing"
-                :class="[
-                  tab.id === activeTabId && 'font-medium !text-ink-gray-8',
-                  tab.id === activeTabId && '!pl-8',
-                ]"
+                :class="tab.id === activeTabId && 'font-medium !text-ink-gray-8'"
                 :label="tab.label"
-                :icon-left="h(LucideFileText, { class: 'size-4 shrink-0' })"
+                :icon-left="
+                  tab.id !== activeTabId
+                    ? h(LucideFileText, { class: 'size-4 shrink-0' })
+                    : undefined
+                "
                 @click="tab.id !== activeTabId && editor.commands.changeTab(tab.id)"
                 :draggable="editor.isEditable"
                 @dragstart="onDragStart($event, tab, index)"
                 @dragend.prevent="onDragEnd"
               >
+                <template #prefix v-if="tab.id === activeTabId">
+                  <Button
+                    @click.stop="showHeadings = !showHeadings"
+                    variant="ghost"
+                    class="!p-0.5 !size-6 -ml-1 -mr-1.5"
+                    :tooltip="showHeadings ? 'Collapse' : 'Expand'"
+                    :icon="h(showHeadings ? LucideMinus : LucidePlus, { class: 'size-3.5' })"
+                  />
+                  <LucideFileText class="size-4 shrink-0" />
+                </template>
                 <template #suffix v-if="tab.id === activeTabId">
                   <div class="ml-auto opacity-0 group-hover:opacity-100 transition-opacity">
                     <Dropdown :options="tabActions">


### PR DESCRIPTION
## What this PR does

**Main fix:** Adds a kebab menu (three-dots) button to the active tab of the document, providing quick access to actions (rename, copy link and delete ) without requiring a right-click context menu.

**Refinements based on maintainer feedback:** 
- Kebab menu only shows when hovering over the active tab
- Moved the existing Expand/Collapse (+/-) button to the left edge for consistent UI behavior

### My initial approach
When I first implemented this, I added the kebab menu button directly to the **right of the existing Plus/Minus button** on the tab container, with both buttons always visible.

### Feedback received
@safwansamsudeen requested that the kebab menu should **only show when the active tab is hovered upon**.

### Why I made the additional changes
Keeping the kebab menu hover-only while leaving the Expand/Collapse button always visible would create **inconsistent UI behavior** on the active tab (one button appearing on hover, another always there). This could cause some confusion for users.

### Final solution
- Added kebab menu button to the **right edge** of the tab
- Made kebab menu **visible only on hover** of the active tab
- **Moved Expand/Collapse (+/-) button to the left edge**
- Kept Expand/Collapse **always visible** (consistent with original behavior)

This creates clear visual separation:
- Left side = persistent navigation/expand actions
- Right side = contextual menu that appears when needed

### Video recording of the happy case

[**Click here to view the demo video**](https://github.com/user-attachments/assets/cc464674-2e4b-436a-88d3-7a3d6a3e3297)

*(Video shows: kebab menu appears on tab hover → actions can be selected → kebab disappears on mouse leave → expand/collapse always accessible on left)*

### Additional suggestion (separate PR)

I believe an **Arrow icon** would be more intuitive than Plus/Minus for expand/collapse functionality. However, I've kept this out of the current PR to maintain focus. If the team agrees, I'm happy to open a separate PR for that icon change.

---

## Note about additional code changes in this PR

I'm developing on **WSL (Windows Subsystem for Linux)**. When I ran `pre-commit` on the `ToC.vue` file,  Prettier automatically formatted the file according to the project's or (I assume) my system's configuration. 

**This means:** The diff shows more changes than just my manual code modifications because Prettier made formatting adjustments to existing code.  **No functional changes were made** outside of the kebab menu implementation described above. 


---

## What was solved
- [x] Added kebab menu to active tabs in the document (main issue)
- [x] Kebab menu shows only on hover of active tab
- [x] Expand/collapse button always visible on left for active tabs
- [x] No changes to existing right-click context menu
- [x] Consistent hover/non-hover UI behavior

---

This solves the issue: **Tabs Actions UX #33** (adding kebab menu) with the requested hover behavior, plus a layout adjustment for UI consistency. Open to feedback and further adjustments if needed.